### PR TITLE
OfType: Type token

### DIFF
--- a/lib/rxdart.dart
+++ b/lib/rxdart.dart
@@ -3,6 +3,10 @@ library rx;
 export 'package:rxdart/src/observable.dart'
     show Observable, observable, Ease, TimeInterval, GroupByMap;
 
+export 'package:rxdart/src/operators/of_type.dart'
+    show TypeToken, kBool, kDouble, kInt, kNum, kString, kSymbol;
+
 export 'package:rxdart/src/subject/behaviour_subject.dart'
     show BehaviourSubject;
+
 export 'package:rxdart/src/subject/replay_subject.dart' show ReplaySubject;

--- a/lib/src/observable.dart
+++ b/lib/src/observable.dart
@@ -11,6 +11,7 @@ import 'package:rxdart/src/observable/merge.dart' show MergeObservable;
 import 'package:rxdart/src/observable/stream.dart' show StreamObservable;
 import 'package:rxdart/src/observable/tween.dart' show TweenObservable, Ease;
 import 'package:rxdart/src/observable/zip.dart' show ZipObservable;
+import 'package:rxdart/src/operators/of_type.dart' show TypeToken;
 import 'package:rxdart/src/operators/time_interval.dart' show TimeInterval;
 import 'package:rxdart/src/operators/group_by.dart' show GroupByMap;
 
@@ -727,8 +728,37 @@ abstract class Observable<T> extends Stream<T> {
   /// sequence according to the specified compare function.
   Observable<T> min([int compare(T a, T b)]);
 
-  /// Filters a sequence so that only events of type pass
-  Observable<S> ofType<S>(S predicate(T event));
+  /// Filters a sequence so that only events of a given type pass
+  ///
+  /// In order to capture the Type correctly, it needs to be wrapped
+  /// in a [TypeToken] as the generic parameter.
+  ///
+  /// Given the way Dart generics work, one cannot simply use the `is T` / `as T`
+  /// checks and castings within `OfTypeObservable` itself. Therefore, the
+  /// [TypeToken] class was introduced to capture the type of class you'd
+  /// like `ofType` to filter down to.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// myObservable.ofType(new TypeToken<num>);
+  /// ```
+  ///
+  /// As a shortcut, you can use some pre-defined constants to write the above
+  /// in the following way:
+  ///
+  /// ```dart
+  /// myObservable.ofType(kNum);
+  /// ```
+  ///
+  /// If you'd like to create your own shortcuts like the example above,
+  /// simply create a constant:
+  ///
+  /// ```dart
+  /// const TypeToken<Map<Int, String>> kMapIntString =
+  ///   const TypeToken<Map<Int, String>>();
+  /// ```
+  Observable<S> ofType<S>(TypeToken<S> typeToken);
 
   /// Creates an Observable containing the value of a specified nested property
   /// from all elements in the Observable sequence. If a property can't be

--- a/lib/src/observable/stream.dart
+++ b/lib/src/observable/stream.dart
@@ -22,7 +22,8 @@ import 'package:rxdart/src/operators/start_with_many.dart'
 import 'package:rxdart/src/operators/repeat.dart' show RepeatObservable;
 import 'package:rxdart/src/operators/min.dart' show MinObservable;
 import 'package:rxdart/src/operators/max.dart' show MaxObservable;
-import 'package:rxdart/src/operators/of_type.dart' show OfTypeObservable;
+import 'package:rxdart/src/operators/of_type.dart'
+    show OfTypeObservable, TypeToken;
 import 'package:rxdart/src/operators/interval.dart' show IntervalObservable;
 import 'package:rxdart/src/operators/sample.dart' show SampleObservable;
 import 'package:rxdart/src/operators/time_interval.dart'
@@ -186,8 +187,9 @@ class StreamObservable<T> implements Observable<T> {
       new MaxObservable<T>(stream, compare);
 
   @override
-  Observable<S> ofType<S>(S predicate(T event)) => new OfTypeObservable<T, S>(
-      stream, predicate);
+  Observable<S> ofType<S>(TypeToken<S> typeToken) {
+    return new OfTypeObservable<T, S>(stream, typeToken);
+  }
 
   @override
   Observable<T> interval(Duration duration) =>

--- a/lib/src/operators/of_type.dart
+++ b/lib/src/operators/of_type.dart
@@ -1,7 +1,7 @@
 import 'package:rxdart/src/observable/stream.dart';
 
 class OfTypeObservable<T, S> extends StreamObservable<S> {
-  OfTypeObservable(Stream<T> stream, S predicate(T event)) {
+  OfTypeObservable(Stream<T> stream, TypeToken<S> typeToken) {
     setStream(stream.transform(
         new StreamTransformer<T, S>((Stream<T> input, bool cancelOnError) {
       StreamController<S> controller;
@@ -11,11 +11,9 @@ class OfTypeObservable<T, S> extends StreamObservable<S> {
           sync: true,
           onListen: () {
             subscription = input.listen((T value) {
-              try {
-                S result = predicate(value);
-
-                if (result != null) controller.add(result);
-              } catch (e) {}
+              if (typeToken.isType(value)) {
+                controller.add(typeToken.toType(value));
+              }
             },
                 onError: controller.addError,
                 onDone: controller.close,
@@ -30,3 +28,61 @@ class OfTypeObservable<T, S> extends StreamObservable<S> {
     })));
   }
 }
+
+/// A class that captures the Type to filter down to using `ofType`.
+///
+/// Given the way Dart generics work, one cannot simply use the `is T` / `as T`
+/// checks and castings within [OfTypeObservable] itself. Therefore, this class
+/// was introduced to capture the type of class you'd like `ofType` to filter
+/// down to.
+///
+/// Example:
+///
+/// ```dart
+/// myObservable.ofType(new TypeToken<num>);
+/// ```
+///
+/// As a shortcut, you can use the pre-defined constants to write the above in
+/// the following way:
+///
+/// ```dart
+/// myObservable.ofType(kNum);
+/// ```
+///
+/// If you'd like to create your own shortcuts like the example above,
+/// simply create a constant:
+///
+/// ```dart
+/// const TypeToken<Map<Int, String>> kMapIntString =
+///   new TypeToken<Map<Int, String>>();
+/// ```
+class TypeToken<S> {
+  const TypeToken();
+
+  bool isType(dynamic other) {
+    return other is S;
+  }
+
+  S toType(dynamic other) {
+    // ignore: avoid_as
+    return other as S;
+  }
+}
+
+/// Filter the observable to only Booleans
+const TypeToken<bool> kBool = const TypeToken<bool>();
+
+/// Filter the observable to only Doubles
+const TypeToken<double> kDouble = const TypeToken<double>();
+
+/// Filter the observable to only Integers
+const TypeToken<int> kInt = const TypeToken<int>();
+
+/// Filter the observable to only Numbers
+const TypeToken<num> kNum = const TypeToken<num>();
+
+/// Filter the observable to only Strings
+const TypeToken<String> kString = const TypeToken<String>();
+
+/// Filter the observable to only Symbols
+const TypeToken<Symbol> kSymbol = const TypeToken<Symbol>();

--- a/test/operators/of_type_test.dart
+++ b/test/operators/of_type_test.dart
@@ -25,23 +25,21 @@ Stream<dynamic> _getStream() {
 void main() {
   test('rx.Observable.ofType', () async {
     observable(_getStream())
-        .ofType((event) => event as Map<String, int>)
+        .ofType(new TypeToken<Map<String, int>>())
         .listen(expectAsync1((Map<String, int> result) {
           expect(result, isMap);
         }, count: 1));
   });
 
   test('rx.Observable.ofType.polymorphism', () async {
-    observable(_getStream())
-        .ofType((event) => event as num)
-        .listen(expectAsync1((num result) {
+    observable(_getStream()).ofType(kNum).listen(expectAsync1((num result) {
           expect(result is num, true);
         }, count: 2));
   });
 
   test('rx.Observable.ofType.asBroadcastStream', () async {
-    Stream<int> stream = observable(_getStream().asBroadcastStream())
-        .ofType((event) => event as int);
+    Stream<int> stream =
+        observable(_getStream().asBroadcastStream()).ofType(kInt);
 
     // listen twice on same stream
     stream.listen((_) {});
@@ -52,7 +50,7 @@ void main() {
 
   test('rx.Observable.ofType.error.shouldThrow', () async {
     Stream<num> observableWithError =
-        observable(getErroneousStream()).ofType((event) => event as num);
+        observable(getErroneousStream()).ofType(kNum);
 
     observableWithError.listen(null, onError: (dynamic e, dynamic s) {
       expect(e, isException);


### PR DESCRIPTION
Hey there,

I was playing with my side-project app this weekend and using `ofType`, and I noticed that the API just feels a bit funny as an end-user. This is a PR that proposes an alternative. Proposal first, explanation follows:

```dart
// Current:
observable.ofType((item) => item as <Map<String, Int>>)

// Proposal: TypeToken
observable.ofType(new TypeToken<Map<String, Int>>())

// TypeToken w/ Shortcut:
const TypeToken<num> kNum = const TypeToken<num>()

observable.ofType(kNum)
```

### Reason

I identified two things that were a bit funny:

  * casting `x as Type` throws lint warnings. What this means you either need to disable that check globally, or in each individual case. Either way, it felt a bit awkward.
  * Passing in a function to `ofType` didn't quite "feel" right either... Perhaps best explained as crazy internal monologue: "Ok, I need to cast to `ofType` -- How do I tell it which type I want? I guess I just try to cast to it and hope for the best?"

### Proposal: TypeToken

Essentially, you create an intermediary class (a `TypeToken`) to capture the type information for the items you want to filter down to. 

#### Downsides:

  * Intermediary `TypeToken` class that is *only* there to capture type info

#### Pros:

  * Possibility to create `shortcuts` like `.ofType(kNum)` or `.ofType(kInt)` which I think read quite well.
  * No more casting / warnings
  * (Subjective) - Passing an object describing which type you want into `ofType` rather than a method that throws or casts.

I borrowed this idea from Java / Guava's TypeToken: https://google.github.io/guava/releases/snapshot/api/docs/com/google/common/reflect/TypeToken.html